### PR TITLE
fix: make AWS profile optional in providers.tf

### DIFF
--- a/scenarios/aws/03-supply-chain/cicd-eic-pivot/terraform/providers.tf
+++ b/scenarios/aws/03-supply-chain/cicd-eic-pivot/terraform/providers.tf
@@ -25,5 +25,5 @@ terraform {
 
 provider "aws" {
   region  = var.region
-  profile = var.profile
+  profile = var.profile != "" ? var.profile : null
 }


### PR DESCRIPTION
Falls back to null when profile is empty, allowing env var credentials without requiring a GnawLab AWS CLI profile to be configured.

## Summary
users to authenticate via environment variables (e.g.,`AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`) without needing a named AWS CLI profile configured locally.

## Type
- [ ] New scenario
- [ ] Scenario update
- [ ] Documentation
- [x] Bug fix
- [ ] Other

## Checklist
- [x] All content in English
- [x] Followed template structure
- [x] Terraform tested (`terraform apply` / `destroy`)
- [x] README, setup.md, cleanup.md, walkthrough.md complete

## Scenario Details (if applicable)
- **Category:** 03-supply-chain/cicd-eic-pivot
- **Difficulty:** Medium
- **Description:** Fixes authentication failure when running the scenario without a local AWS CLI profile

## Related Issues
<!-- Fixes #123 -->

