### PR TITLE
docs: sync README with implemented scenarios

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,22 +34,29 @@ Just as beavers build dams piece by piece, we build cloud security knowledge ste
 
 ## Scenarios
 
-### AWS
+GnawLab currently contains **14 deployable AWS scenarios** and **3 planned scenarios**. An available scenario includes Terraform infrastructure and scenario-specific setup, walkthrough, and cleanup documentation.
 
-| Category | Scenario | Status | Description |
-|----------|----------|--------|-------------|
-| **01-beginner** | [s3-data-heist](./scenarios/aws/01-beginner/01-single-hop/s3-data-heist/) | ✅ Available | S3 bucket misconfiguration exploitation |
-| | [ebs-snapshot-theft](./scenarios/aws/01-beginner/01-single-hop/ebs-snapshot-theft/) | ✅ Available | EBS snapshot exposure and data extraction |
-| | [metadata-pivot](./scenarios/aws/01-beginner/02-single-hop-combo/metadata-pivot/) | ✅ Available | SSRF to IMDS credential theft |
-| | [secrets-extraction](./scenarios/aws/01-beginner/02-single-hop-combo/secrets-extraction/) | ✅ Available | Secrets Manager extraction via command injection |
-| | [policy-rollback](./scenarios/aws/01-beginner/02-single-hop-combo/policy-rollback/) | ✅ Available | IAM policy version rollback privilege escalation |
-| | [credential-chain](./scenarios/aws/01-beginner/03-multi-hop/credential-chain/) | 🚧 Coming Soon | Multi-hop credential pivoting |
-| | [ec2-role-hijack](./scenarios/aws/01-beginner/04-multi-hop-combo/ec2-role-hijack/) | 🚧 Coming Soon | EC2 instance role hijacking via PassRole |
-| | [lambda-backdoor](./scenarios/aws/01-beginner/04-multi-hop-combo/lambda-backdoor/) | 🚧 Coming Soon | Lambda function backdoor via PassRole |
-| **02-shadow-api** | [legacy-bridge](./scenarios/aws/02-shadow-api/legacy-bridge/) | ✅ Available | Shadow API discovery and exploitation |
-| **03-supply-chain** | [cicd-eic-pivot](./scenarios/aws/03-supply-chain/cicd-eic-pivot/) | ✅ Available | CI/CD pipeline exploitation via EIC |
-| **04-ai-security** | [bedrock-kb-poisoning](./scenarios/aws/04-ai-security/bedrock-kb-poisoning/) | ✅ Available | Bedrock Knowledge Base data poisoning |
-| **05-zero-trust** | [watchdog_trap](./scenarios/aws/05-zero-trust/watchdog_trap/) | ✅ Available | Zero trust bypass techniques |
+| Category | Scenario | Difficulty | Status | Attack path |
+|----------|----------|------------|--------|-------------|
+| **01-beginner** | [s3-data-heist](./scenarios/aws/01-beginner/01-single-hop/s3-data-heist/) | Easy | ✅ Available | Leaked IAM credentials → S3 enumeration and data exfiltration |
+| | [ebs-snapshot-theft](./scenarios/aws/01-beginner/01-single-hop/ebs-snapshot-theft/) | Easy | ✅ Available | Exposed EBS snapshot → attacker EC2 instance → data extraction |
+| | [metadata-pivot](./scenarios/aws/01-beginner/02-single-hop-combo/metadata-pivot/) | Medium | ✅ Available | SSRF → IMDS credentials → S3 data exfiltration |
+| | [secrets-extraction](./scenarios/aws/01-beginner/02-single-hop-combo/secrets-extraction/) | Easy | ✅ Available | Command injection → ECS task credentials → Secrets Manager |
+| | [policy-rollback](./scenarios/aws/01-beginner/02-single-hop-combo/policy-rollback/) | Medium | ✅ Available | IAM policy version rollback → privilege escalation |
+| | [credential-chain](./scenarios/aws/01-beginner/03-multi-hop/credential-chain/) | Hard | 🚧 Planned | Multi-service credential chaining and escalation |
+| | [ec2-role-hijack](./scenarios/aws/01-beginner/04-multi-hop-combo/ec2-role-hijack/) | Hard | 🚧 Planned | PassRole → EC2 launch with a privileged role |
+| | [lambda-backdoor](./scenarios/aws/01-beginner/04-multi-hop-combo/lambda-backdoor/) | Hard | 🚧 Planned | PassRole → privileged Lambda code execution |
+| **02-shadow-api** | [legacy-bridge](./scenarios/aws/02-shadow-api/legacy-bridge/) | Easy | ✅ Available | SSRF into a legacy API → IMDSv1 credentials → S3 exfiltration |
+| | [code-judge-escape](./scenarios/aws/02-shadow-api/code-judge-escape/) | Hard | ✅ Available | Pickle RCE → Docker socket → IMDSv2 → ECS Exec |
+| **03-supply-chain** | [cicd-eic-pivot](./scenarios/aws/03-supply-chain/cicd-eic-pivot/) | Medium | ✅ Available | Atlantis CI/CD abuse → IAM credentials → EC2 Instance Connect |
+| | [golden-drift](./scenarios/aws/03-supply-chain/golden-drift/) | Medium | ✅ Available | AMI name confusion → SSM pointer poisoning → ASG compromise |
+| | [dam-breaks](./scenarios/aws/03-supply-chain/dam-breaks/) | Medium | ✅ Available | Cognito credentials → CodeBuild override → ECS task role |
+| **04-ai-security** | [bedrock-kb-poisoning](./scenarios/aws/04-ai-security/bedrock-kb-poisoning/) | Hard | ✅ Available | RAG corpus poisoning → indirect prompt injection → unauthorized presigned URL |
+| **05-zero-trust** | [watchdog-trap](./scenarios/aws/05-zero-trust/watchdog_trap/) | Hard | ✅ Available | SSTI/RCE → internal tool pivot → CI/CD and ECS compromise |
+| **06-misconfiguration** | [obfuscated-policy](./scenarios/aws/06-misconfiguration/obfuscated-policy/) | Easy | ✅ Available | IAM action wildcard obfuscation → detector bypass → S3 access |
+| **07-cve** | [hidden-track](./scenarios/aws/07-cve/hidden-track/) | Medium | ✅ Available | ExifTool CVE-2021-22204 → Lambda credentials → S3 version recovery |
+
+Difficulty values and detailed prerequisites are maintained in each scenario's README and setup guide.
 
 ---
 
@@ -57,61 +64,70 @@ Just as beavers build dams piece by piece, we build cloud security knowledge ste
 
 ### Prerequisites
 
-- [Terraform](https://www.terraform.io/downloads) >= 1.5.0
-- [AWS CLI](https://aws.amazon.com/cli/) v2
-- AWS Account with admin access (for resource creation)
+- [Terraform](https://developer.hashicorp.com/terraform/install) >= 1.5.0
+- [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html) v2
+- An AWS account with permissions to create the resources listed by the selected scenario
+- Any additional tools listed in that scenario's `setup.md`
 
-### AWS CLI Profile Setup
+> [!CAUTION]
+> These scenarios intentionally deploy vulnerable resources and may incur AWS charges. Deploy them only in an account you control, restrict access as described in the setup guide, and remove all resources when finished.
 
-All GnawLab scenarios use the `GnawLab` AWS CLI profile:
+### Configure AWS Credentials
+
+Most scenarios default to the `GnawLab` AWS CLI profile and the `us-east-1` region:
 
 ```bash
 aws configure --profile GnawLab
-# AWS Access Key ID: <your-admin-access-key>
-# AWS Secret Access Key: <your-admin-secret-key>
-# Default region name: us-east-1
-# Default output format: json
+aws sts get-caller-identity --profile GnawLab
 ```
+
+You can select another profile where supported by passing a Terraform variable, for example `-var="profile=my-admin-profile"`. `watchdog-trap` instead uses the standard AWS credential chain (default profile or environment variables); see its setup guide.
 
 ### Deploy a Scenario
 
+Read the scenario's `README.md` and `setup.md` before deploying. For example:
+
 ```bash
-cd scenarios/aws/01-beginner/01-single-hop/s3-data-heist/terraform
+cd scenarios/aws/01-beginner/01-single-hop/s3-data-heist
+cat setup.md
+cd terraform
 terraform init
+terraform plan
 terraform apply
 ```
 
-### Get Scenario Credentials
+Inspect the scenario-specific outputs after deployment:
 
 ```bash
-terraform output -json leaked_credentials
+terraform output
 ```
 
-Configure a separate profile for the challenge:
-
-```bash
-aws configure --profile victim
-# Use the leaked credentials from terraform output
-```
+Output names, participant starting points, required post-deployment steps, and deployment times vary by scenario. Follow the selected scenario's setup guide rather than assuming credentials are always returned. For example, [`watchdog-trap`](./scenarios/aws/05-zero-trust/watchdog_trap/setup.md) recommends its automated `deploy.sh` flow.
 
 ### Cleanup
 
+Read the scenario's `cleanup.md` first. Some challenges create participant-managed resources that must be removed before Terraform can destroy the lab infrastructure.
+
 ```bash
+# Run any scenario-specific pre-cleanup steps first.
+cd terraform
 terraform destroy
 ```
+
+Confirm that the destroy completed successfully and check the AWS account for any remaining scenario resources.
 
 ---
 
 ## Community
 
 - [LinkedIn Group](https://www.linkedin.com/groups/14865006/) — Join the Beaver Dam Community
-- [GitHub Issues](../../issues) — Report bugs or request features
+- [GitHub Issues](https://github.com/Beaver-Dam-Community/GnawLab/issues) — Report bugs or request features
 
 ---
 
 ## Contributing
 
-We welcome contributions! Whether it's a new scenario, bug fix, or documentation improvement.
+We welcome contributions, whether they add a new scenario, fix a bug, or improve documentation.
 
 See [CONTRIBUTING.md](./CONTRIBUTING.md) for guidelines.
 
@@ -119,4 +135,4 @@ See [CONTRIBUTING.md](./CONTRIBUTING.md) for guidelines.
 
 ## License
 
-This project is for educational purposes only. Use responsibly and only in environments you own or have explicit permission to test.
+Licensed under the [Apache License 2.0](./LICENSE). These intentionally vulnerable scenarios are for educational use only. Use them responsibly and only in environments you own or have explicit permission to test.


### PR DESCRIPTION
## Summary
Synchronize the main README with the scenarios and deployment behavior currently implemented in the repository.

## Type
- [ ] New scenario
- [ ] Scenario update
- [x] Documentation
- [ ] Bug fix
- [ ] Other

## Checklist
- [x] All content in English
- [x] Followed the existing README structure
- [ ] Terraform tested (`terraform apply` / `destroy`) — not applicable to this documentation-only change
- [x] Main README updated; scenario-specific documentation is unchanged

## Security Checklist
- [x] AWS Account ID uses placeholder only (`123456789012`, etc.)
- [x] No real credentials included (Access Key, Secret Key, Password)
- [x] IAM permissions are unchanged

## Changes
- List all 14 deployable and 3 planned AWS scenarios with difficulty and attack path
- Add the five implemented scenarios missing from the previous main README
- Align credential, deployment-output, and cleanup guidance with scenario-specific behavior
- Document the `watchdog-trap` credential-chain and automated deployment exception
- Fix the GitHub Issues and Apache License links
- Add vulnerable-resource and AWS cost warnings

## Scenario Details (if applicable)
Not applicable — repository-level documentation update only.

## Related Issues
None.

## Validation
- `git diff --check`
- Automated comparison of README scenario links against all 17 Difficulty-marked scenario directories
- Verified all 20 local Markdown links resolve
